### PR TITLE
Added FHIR $match Operation

### DIFF
--- a/SanteDB.Messaging.FHIR/FhirQuery.cs
+++ b/SanteDB.Messaging.FHIR/FhirQuery.cs
@@ -80,5 +80,9 @@ namespace SanteDB.Messaging.FHIR
         /// </summary>
         public int Quantity { get; set; }
 
+        /// <summary>
+        /// The resource type
+        /// </summary>
+        public String ResouceType { get; }
     }
 }

--- a/SanteDB.Messaging.FHIR/Handlers/IFhirResourceHandler.cs
+++ b/SanteDB.Messaging.FHIR/Handlers/IFhirResourceHandler.cs
@@ -18,6 +18,7 @@
  */
 using Hl7.Fhir.Model;
 using SanteDB.Core.Services;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 

--- a/SanteDB.Messaging.FHIR/Handlers/IFhirResourceMapper.cs
+++ b/SanteDB.Messaging.FHIR/Handlers/IFhirResourceMapper.cs
@@ -17,45 +17,35 @@
  * Date: 2019-11-27
  */
 using Hl7.Fhir.Model;
-using System.Collections.Generic;
+using SanteDB.Core.Model;
+using System;
 
-namespace SanteDB.Messaging.FHIR
+namespace SanteDB.Messaging.FHIR.Handlers
 {
     /// <summary>
-    /// Query result form a FHIR query
+    /// Represents a resource handler than can map objects
     /// </summary>
-    public class FhirQueryResult
+    public interface IFhirResourceMapper : IFhirResourceHandler
     {
 
         /// <summary>
-        /// Create a new fhir query result
+        /// Gets the canonical type
         /// </summary>
-        /// <param name="resourceType"></param>
-        public FhirQueryResult(string resourceType)
-        {
-            this.ResourceType = resourceType;
-            this.Results = new List<Resource>();
-        }
+        Type CanonicalType { get; }
 
         /// <summary>
-        /// Gets or sets the results
+        /// Map <paramref name="modelInstance"/> to FHIR
         /// </summary>
-        public List<Resource> Results { get; set; }
+        /// <param name="modelInstance">The object to map to fhir</param>
+        /// <returns>The mapped FHIR instance</returns>
+        Resource MapToFhir(IdentifiedData modelInstance);
 
         /// <summary>
-        /// Gets or sets the query that initiated the action
+        /// Map the specified <paramref name="resourceInstance"/> to model
         /// </summary>
-        public FhirQuery Query { get; set; }
-
-        /// <summary>
-        /// Gets the total results
-        /// </summary>
-        public int TotalResults { get; set; }
-
-        /// <summary>
-        /// Resource type
-        /// </summary>
-        public string ResourceType { get; }
+        /// <param name="resourceInstance">The resource to map</param>
+        /// <returns>The model instance</returns>
+        IdentifiedData MapToModel(Resource resourceInstance);
 
     }
 }

--- a/SanteDB.Messaging.FHIR/Handlers/ObservationResourceHandler.cs
+++ b/SanteDB.Messaging.FHIR/Handlers/ObservationResourceHandler.cs
@@ -173,7 +173,7 @@ namespace SanteDB.Messaging.FHIR.Handlers
             var restOperationContext = RestOperationContext.Current;
 
             // Return FHIR query result
-            return new FhirQueryResult()
+            return new FhirQueryResult("Observation")
             {
                 Results = hdsiResults.Select(o => this.MapToFhir(o, restOperationContext)).OfType<Resource>().ToList(),
                 Query = query,

--- a/SanteDB.Messaging.FHIR/Operations/FhirMatchResourceOperation.cs
+++ b/SanteDB.Messaging.FHIR/Operations/FhirMatchResourceOperation.cs
@@ -1,0 +1,163 @@
+﻿using Hl7.Fhir.Model;
+using RestSrvr;
+using SanteDB.Core;
+using SanteDB.Core.Configuration;
+using SanteDB.Core.Diagnostics;
+using SanteDB.Core.Services;
+using SanteDB.Messaging.FHIR.Extensions;
+using SanteDB.Messaging.FHIR.Handlers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SanteDB.Messaging.FHIR.Operations
+{
+    /// <summary>
+    /// A FHIR operation handler which executs the matching logic of the CDR
+    /// </summary>
+    public class FhirMatchResourceOperation : IFhirOperationHandler
+    {
+        // Tracer
+        private readonly Tracer m_tracer = Tracer.GetTracer(typeof(FhirMatchResourceOperation));
+
+        // Configuration
+        private ResourceMergeConfigurationSection m_configuration;
+
+        /// <summary>
+        /// Configurations for the merge configuration
+        /// </summary>
+        public FhirMatchResourceOperation()
+        {
+            this.m_configuration = ApplicationServiceContext.Current.GetService<IConfigurationManager>().GetSection<ResourceMergeConfigurationSection>();
+        }
+
+        /// <summary>
+        /// Gets the name of the operation
+        /// </summary>
+        public string Name => "match";
+
+        /// <summary>
+        /// Gets the URI where this operation is defined
+        /// </summary>
+        public Uri Uri => new Uri("OperationDefinition/match", UriKind.Relative);
+
+        /// <summary>
+        /// Applies to which resources (all of them)
+        /// </summary>
+        public ResourceType? AppliesTo => null;
+
+        /// <summary>
+        /// Invoke the specified operation
+        /// </summary>
+        public Resource Invoke(Parameters parameters)
+        {
+
+            // Validate parameters
+            var resource = parameters.Parameter.FirstOrDefault(o => o.Name == "resource")?.Resource;
+            var onlyCertainMatches = parameters.Parameter.FirstOrDefault(o => o.Name == "onlyCertainMatches")?.Value as FhirBoolean ?? new FhirBoolean(false);
+            var count = parameters.Parameter.FirstOrDefault(o => o.Name == "count")?.Value as Integer;
+
+            if (resource == null)
+                throw new ArgumentNullException("Missing resource parameter");
+
+            // Execute the logic
+            try
+            {
+                // First we want to get the handler, as this will tell us the SanteDB CDR type 
+                var handler = FhirResourceHandlerUtil.GetResourceHandler(resource.ResourceType) as IFhirResourceMapper;
+                if (handler == null)
+                    throw new NotSupportedException($"Operation on {resource.ResourceType} not supported");
+
+                var matchService = ApplicationServiceContext.Current.GetService<IRecordMatchingService>();
+                if (matchService == null)
+                    throw new NotSupportedException($"No match service is registered on this CDR");
+
+                // Now we want to map the from FHIR to our CDR model
+                var modelInstance = handler.MapToModel(resource);
+                this.m_tracer.TraceInfo("Will execute match on {0}", modelInstance);
+
+                // Next run the match
+                var configurationName = RestOperationContext.Current.IncomingRequest.QueryString["_configurationName"];
+                IEnumerable<IRecordMatchResult> results = null;
+                if (!String.IsNullOrEmpty(configurationName))
+                {
+                    results = matchService.Match(modelInstance, configurationName).ToArray();
+                }
+                else // use the configured option
+                {
+                    var configBase = this.m_configuration.ResourceTypes.FirstOrDefault(o => o.ResourceType == modelInstance.GetType());
+                    if (configBase == null)
+                    {
+                        throw new InvalidOperationException($"No resource merge configuration for {modelInstance.GetType()} available. Use either ?_configurationName parameter to add a ResourceMergeConfigurationSection to your configuration file");
+                    }
+
+                    results = configBase.MatchConfiguration.SelectMany(o => matchService.Match(modelInstance, o)).ToArray();
+                }
+
+                // Next we want to convert to FHIR
+                var retVal = new Bundle()
+                {
+                    Id = $"urn:uuid:{Guid.NewGuid()}",
+                    Meta = new Meta()
+                    {
+                        LastUpdated = DateTimeOffset.Now
+                    },
+                    Type = Bundle.BundleType.Searchset,
+                    Total = results.Count(),
+                };
+
+                // Iterate through the resources and convert them to FHIR
+                // Grouping by the ID of the candidate and selecting the highest rated match
+                retVal.Entry = results.GroupBy(o => o.Record.Key).Select(o => o.OrderByDescending(m => m.Score).First())
+                    .Select(o => this.ConvertMatchResult(o, handler)).ToList();
+
+                return retVal;
+            }
+            catch(Exception e)
+            {
+                this.m_tracer.TraceError($"Error running match on {resource.ResourceType} - {e}");
+                throw new Exception($"Error running match operation on {resource.ResourceType}", e);
+            }
+        }
+
+        /// <summary>
+        /// Convert match result <paramref name="matchResult"/> to a FHIR resource
+        /// </summary>
+        private Bundle.EntryComponent ConvertMatchResult(IRecordMatchResult matchResult, IFhirResourceMapper mapper)
+        {
+            var result = mapper.MapToFhir(matchResult.Record);
+
+            // Now publish search data
+            return new Bundle.EntryComponent()
+            {
+                FullUrl = $"{result.ResourceType}/{result.Id}/_history/{result.VersionId}",
+                Resource = result,
+                Search = new Bundle.SearchComponent()
+                {
+                    Mode = Bundle.SearchEntryMode.Match,
+                    Score = (decimal)matchResult.Strength,
+                    Extension = new List<Extension>()
+                    {
+                        new Extension()
+                        {
+                            Url = "http://hl7.org/fhir/StructureDefinition/match-grade",
+                            Value = new Code(matchResult.Classification == RecordMatchClassification.Match ? "certain" : matchResult.Classification == RecordMatchClassification.Probable ? "possible" : "certainly-not")
+                        },
+                        new Extension()
+                        {
+                            Url = "http://santedb.org/fhir/StructureDefinition/match-method",
+                            Value = new Code(matchResult.Method.ToString())
+                        },
+                        new Extension()
+                        {
+                            Url = "http://santedb.org/fhir/StructureDefinition/raw-score",
+                            Value = new FhirDecimal((decimal)matchResult.Score)
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/SanteDB.Messaging.FHIR/Properties/AssemblyInfo.cs
+++ b/SanteDB.Messaging.FHIR/Properties/AssemblyInfo.cs
@@ -51,10 +51,10 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("2.1.0.*")][assembly: AssemblyInformationalVersion("Ottawa")]
-[assembly: AssemblyVersion("2.1.0.*")]
+// [assembly: AssemblyVersion("2.1.1.*")][assembly: AssemblyInformationalVersion("Ottawa")]
+[assembly: AssemblyVersion("2.1.1.*")]
 [assembly: AssemblyInformationalVersion("Ottawa")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]
 
 [assembly: Plugin(EnableByDefault = false, Environment = PluginEnvironment.Server, Group = FeatureGroup.Messaging)]
 [assembly: PluginTraceSource(FhirConstants.TraceSourceName)]

--- a/SanteDB.Messaging.FHIR/Rest/IFhirServiceContract.cs
+++ b/SanteDB.Messaging.FHIR/Rest/IFhirServiceContract.cs
@@ -96,7 +96,7 @@ namespace SanteDB.Messaging.FHIR.Rest
         /// <param name="operationName">The name of the operation</param>
         /// <returns>The result of the operation</returns>
         /// <param name="parameters">The body to pass as a parameter to the operation</param>
-        [Post("/{resourceType}/${operationName}")]
+        [Post("/{resourceType}/\\${operationName}")]
         Resource Execute(string resourceType, string operationName, Parameters parameters);
 
         /// <summary>

--- a/SanteDB.Messaging.FHIR/SanteDB.Messaging.FHIR.csproj
+++ b/SanteDB.Messaging.FHIR/SanteDB.Messaging.FHIR.csproj
@@ -121,10 +121,10 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="RestSrvr" Version="2.1.0.0" />
-        <PackageReference Include="SanteDB.Core.Api" Version="2.1.0.0" />
-        <PackageReference Include="SanteDB.Core.Model" Version="2.1.0.0" />
-        <PackageReference Include="SanteDB.Rest.Common" Version="2.1.0.0" />
+        <PackageReference Include="RestSrvr" Version="2.1.1.0" />
+        <PackageReference Include="SanteDB.Core.Api" Version="2.1.1.0" />
+        <PackageReference Include="SanteDB.Core.Model" Version="2.1.1.0" />
+        <PackageReference Include="SanteDB.Rest.Common" Version="2.1.1.0" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/SanteDB.Messaging.FHIR/SanteDB.Messaging.FHIR.csproj
+++ b/SanteDB.Messaging.FHIR/SanteDB.Messaging.FHIR.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Handlers\EncounterResourceHandler.cs" />
     <Compile Include="Handlers\FhirResourceHandlerUtil.cs" />
     <Compile Include="Handlers\IFhirResourceHandler.cs" />
+    <Compile Include="Handlers\IFhirResourceMapper.cs" />
     <Compile Include="Handlers\LocationResourceHandler.cs" />
     <Compile Include="Handlers\MedicationAdministrationResourceHandler.cs" />
     <Compile Include="Handlers\MedicationResourceHandler.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="Handlers\SubstanceResourceHandler.cs" />
     <Compile Include="Extensions\IFhirProfileHandler.cs" />
     <Compile Include="Extensions\IFhirOperationHandler.cs" />
+    <Compile Include="Operations\FhirMatchResourceOperation.cs" />
     <Compile Include="Operations\FhirValidateResourceOperation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rest\Behaviors\FhirMessageDispatchFormatterEndpointBehavior.cs" />

--- a/SanteDB.Messaging.FHIR/SanteDB.Messaging.FHIR.nuspec
+++ b/SanteDB.Messaging.FHIR/SanteDB.Messaging.FHIR.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>SanteDB.Messaging.FHIR</id>
-    <version>2.1.0.0</version>
+    <version>2.1.1.0</version>
     <title>HL7 FHIR Bindings for SanteDB Server</title>
     <authors>SanteDB Community</authors>
     <owners>santedb.org</owners>
@@ -15,12 +15,12 @@
     <copyright>Copyright (C) 2015-2020 SanteSuite Contributors (See: NOTICES)</copyright>
     <tags>cdr santedb fhir</tags>
     <dependencies>
-      <dependency id="SanteDB.Core.Api" version="2.1.0.0" />
-      <dependency id="SanteDB.Core.Model" version="2.1.0.0" />
+      <dependency id="SanteDB.Core.Api" version="2.1.1.0" />
+      <dependency id="SanteDB.Core.Model" version="2.1.1.0" />
       <dependency id="Hl7.Fhir.R4" version="1.4.0" />
       <dependency id="Newtonsoft.Json" version="12.0.3.0" />
-      <dependency id="Restsrvr" version="2.1.0.0" />
-      <dependency id="SanteDB.Rest.Common" version="2.1.0.0" />
+      <dependency id="Restsrvr" version="2.1.1.0" />
+      <dependency id="SanteDB.Rest.Common" version="2.1.1.0" />
     </dependencies>
   </metadata>
 </package>

--- a/SanteDB.Messaging.FHIR/Util/QueryRewriter.cs
+++ b/SanteDB.Messaging.FHIR/Util/QueryRewriter.cs
@@ -38,26 +38,6 @@ namespace SanteDB.Messaging.FHIR.Util
 {
 
     /// <summary>
-    /// SanteDB FHIR query
-    /// </summary>
-    public class SanteDBFhirQuery<TModel> : FhirQuery
-    {
-
-        /// <summary>
-        /// Query expression
-        /// </summary>
-        public LambdaExpression QueryExpression { get; set; }
-
-        /// <summary>
-        /// Gets or sets the composed query
-        /// </summary>
-        public Expression<Func<TModel, bool>> ToPredicate()
-        {
-            return System.Linq.Expressions.Expression.Lambda<Func<TModel, bool>>(this.QueryExpression.Body, this.QueryExpression.Parameters);
-        }
-    }
-
-    /// <summary>
     /// A class which is responsible for translating a series of Query Parmaeters to a LINQ expression
     /// to be passed to the persistence layer
     /// </summary>


### PR DESCRIPTION
Added the FHIR $match operation to the FHIR contract. And added the operation to Swagger docs for easy commit.

Notes about using the match operation:

+ The operation works on any resource which has a IFhirResourceMapping service
+ The operation does not currently adhere to confirmed matches or count parameters
+ The operation requires a valid patient to be submitted or else you'll receive a rejected message.

Test with the sample found on the HL7 FHIR Operation documentation page for match operation. The 2.1.1 version packages this references have not been published to NUGET. You'll need to compile this inside of the santedb-server-ext.sln file from santedb-server project or you'll need to build the latest develop branch on the santedb service with build-nuget-symbols.bat.